### PR TITLE
Removed sudo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## The Lazy:
 
 ```
-sudo pip install cftpl
+pip install cftpl
 ```
 
 `cfmgr` should be available now:


### PR DESCRIPTION
Don't suggest installing anything from pip via sudo.
